### PR TITLE
Fix broken link

### DIFF
--- a/src/site/index.html
+++ b/src/site/index.html
@@ -173,7 +173,7 @@
     }
 }</code></pre>
 
-        <p>The <a href="/asciidoc/html5/">User Guide</a> provides more detailed information about configuring and using the plugin.</p>
+        <p>The <a href="asciidoc/html5">User Guide</a> provides more detailed information about configuring and using the plugin.</p>
 
     </div>
     <div id="push"></div>


### PR DESCRIPTION
Fix a broken link "User Guide" at the bottom of https://http-builder-ng.github.io/gradle-http-plugin/index.html